### PR TITLE
Add non-default sphinx-linkcheck docs dir path

### DIFF
--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -21,3 +21,4 @@ jobs:
       python-version: ${{ matrix.python-version }}
       conda-env-file: environment-rtd.yaml
       conda-env-name: salishseacast-docs
+      docs-dir: .


### PR DESCRIPTION
Docs repos are special cases for sphinx-linkcheck workflow because the
RST files are in the top level rather than being in a `docs/` directory
as is the case in Python package repos.
Missed in 7a30a1.