### PR TITLE
Update to Python 3.12

### DIFF
--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -5,6 +5,9 @@ on:
     branches: ['*']
   schedule:
     - cron: 43 4 8 * *  # 04:43 UTC on the 8th day of each month
+  # Enable workflow to be triggered from GitHub CLI, browser, or via API
+  # primarily for testing conda env solution for new Python versions
+  workflow_dispatch:
 
 jobs:
   sphinx-linkcheck:

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         # Need to specify Python version here because we use test env which gets its
         # Python version via matrix
-        python-version: [ '3.10', '3.11', '3.12' ]
+        python-version: [ '3.12' ]
     uses: UBC-MOAD/gha-workflows/.github/workflows/sphinx-linkcheck.yaml@main
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/sphinx-linkcheck.yaml
+++ b/.github/workflows/sphinx-linkcheck.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # Need to specify Python version here because we use test env which gets its
         # Python version via matrix
-        python-version: [ '3.10' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
     uses: UBC-MOAD/gha-workflows/.github/workflows/sphinx-linkcheck.yaml@main
     with:
       python-version: ${{ matrix.python-version }}

--- a/code-notes/salishsea-nemo/nemo-forcing/atmospheric.rst
+++ b/code-notes/salishsea-nemo/nemo-forcing/atmospheric.rst
@@ -90,7 +90,7 @@ An example of the use of :program:`get_weight_nemo` to create a weights file for
 operational West deployment of Environment Canada's `High Resolution Deterministic Prediction 
 System`_ (HRDPS) is presented here:
 
-.. _High Resolution Deterministic Prediction System: https://weather.gc.ca/grib/grib2_HRDPS_HR_e.html
+.. _High Resolution Deterministic Prediction System: https://eccc-msc.github.io/open-data/msc-data/nwp_hrdps/readme_hrdps_en/
 
 Clone the :ref:`NEMO_EastCoast-repo` repo on :kbd:`salish` and edit the 
 :file:`NEMO_Preparation/4_weights_ATMOS/make.sh` file to comment out the default build commands 

--- a/code-notes/salishsea-nemo/quickstart/graham.rst
+++ b/code-notes/salishsea-nemo/quickstart/graham.rst
@@ -285,7 +285,7 @@ or observations:
 * Atmospheric forcing is almost always from the Environment and Climate Change Canada (ECCC) 
   `High Resolution Deterministic Prediction System`_ (HRDPS) model hourly forecasts.
 
-  .. _High Resolution Deterministic Prediction System: https://weather.gc.ca/grib/grib2_HRDPS_HR_e.html
+  .. _High Resolution Deterministic Prediction System: https://eccc-msc.github.io/open-data/msc-data/nwp_hrdps/readme_hrdps_en/
 
 * Tides are,
   by definition,

--- a/code-notes/salishsea-nemo/quickstart/graham.rst
+++ b/code-notes/salishsea-nemo/quickstart/graham.rst
@@ -255,6 +255,23 @@ Please see :command:`salishsea help run` or the
 You can use the batch job number with :command:`squeue --job` and :command:`sacct --job` 
 to monitor the execution status of your job.
 
+The command alias:
+
+.. code-block:: bash
+
+    alias sq='squeue -o "%.12i %.8u %.9a %.22j %.2t %.10r %.19S %.10M %.10L %.6D %.5C %P %N"'
+
+provides more informative output from :command:`squeue`.
+Add the alias to your :file:`$HOME/.bashrc` file so that it is available in every terminal session.
+You can use as:
+
+* :command:`sq -u $USER` to see all of your queued jobs
+* :command:`sq -A rrg-allen,def-allen` to see all of the group's queued jobs
+* :command:`sq --job job-number`,
+  where `job-number` is the batch job number provided in the output of a :command:`salishsea run` 
+  command,
+  to see the information about a specific job
+
 When the job completes the results should have been gathered in the directory you specified 
 in the :command:`salishsea run` command and the temporary run directory should have been deleted.
 

--- a/code-notes/salishsea-nemo/quickstart/graham.rst
+++ b/code-notes/salishsea-nemo/quickstart/graham.rst
@@ -223,7 +223,7 @@ The run description file is described in the :ref:`salishseacmd:RunDescriptionFi
 of the :ref:`salishseacmd:SalishSeaCmdProcessor` documentation.
 The namelists are described in the `NEMO-3.6 Book`_.
 
-.. _NEMO-3.6 Book: https://zenodo.org/record/3248739
+.. _NEMO-3.6 Book: https://zenodo.org/records/3248739
 
 Please see the sections below for details of using forcing climatology and 
 shared daily forcing files in your runs,

--- a/code-notes/salishsea-nemo/quickstart/graham.rst
+++ b/code-notes/salishsea-nemo/quickstart/graham.rst
@@ -103,6 +103,10 @@ Download and install the Miniforge distribution of :program:`conda`:
     wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
     bash Miniforge3-Linux-x86_64.sh
 
+Accept the defaults offered for all of the settings.
+Exit your terminal session on ``graham`` with :command:`exit` and start a new session to ensure that
+the Miniforge configuration takes effect and the :command:`conda` command is available.
+
 Create a ``salishsea-cmd`` conda environment:
 
 .. code-block:: bash

--- a/environment-rtd.yaml
+++ b/environment-rtd.yaml
@@ -26,6 +26,6 @@ dependencies:
   - ipython
   - nbsphinx
   - pip
-  - python=3.10
+  - python=3.12
   - sphinx
   - sphinx_rtd_theme=1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ tinycss2==1.2.1
 tornado==6.3.3
 traitlets==5.9.0
 typing_extensions==4.5.0
-urllib3==1.26.17
+urllib3==1.26.18
 wcwidth==0.2.6
 webencodings==0.5.1
 wheel==0.40.0


### PR DESCRIPTION
- [x] Add Python 3.12 to GHA sphinx-linkcheck workflow so that we can use the workflow to test whether all the packages that the docs build depends on have been updated to support Python 3.12.
- [x] Add `workflow_dispatch` trigger to GHA sphinx-linkcheck workflow to enable workflow to be triggered from
GitHub CLI, browser or via API
- [x] Change to Python 3.12 for docs development