### PR TITLE
Add sphinx-notfound-page extension to docs build

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -24,6 +24,7 @@ import os
 # or your custom ones.
 extensions = [
     'nbsphinx',
+    "notfound.extension",
     'IPython.sphinxext.ipython_console_highlighting',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',

--- a/environment-rtd.yaml
+++ b/environment-rtd.yaml
@@ -31,3 +31,5 @@ dependencies:
 
   - pip:
     - sphinx_rtd_theme
+    - sphinx-notfound-page
+    

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,6 +63,7 @@ six==1.16.0
 snowballstemmer==2.2.0
 soupsieve==2.5
 Sphinx==7.2.6
+sphinx-notfound-page==1.0.0
 sphinx-rtd-theme==2.0.0
 sphinxcontrib-applehelp==1.0.8
 sphinxcontrib-devhelp==1.0.6


### PR DESCRIPTION
Ensures that static assets load in the event of a 404 for a better UX. Facilitates future customization of 404 page.