### PR TITLE
Update instructions for using Alliance HPC clusters

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,22 @@
 {
     "restructuredtext.confPath": "${workspaceFolder}",
     "cSpell.words": [
+        "alliancecan",
+        "ECCC",
         "ERDDAP",
+        "Fuca",
+        "HRDPS",
+        "Johnstone",
+        "MEOPAR",
+        "Miniforge",
         "NEMO",
-        "Tsawwassen"
+        "nibi",
+        "orcinus",
+        "Pawlowicz",
+        "Pieters",
+        "salishsea",
+        "Tsawwassen",
+        "XIOS"
     ],
     "makefile.configureOnOpen": false
 }

--- a/code-notes/dev-notes/nemo_3.4_westgrid.rst
+++ b/code-notes/dev-notes/nemo_3.4_westgrid.rst
@@ -7,7 +7,7 @@ Getting your Jasper Shell Ready
 -------------------------------
 
 * make sure your shell is bash (echo $SHELL), if its not, write to Westgrid support and get it changed.
-* follow the instructions in :ref:`moaddocs:InitialSetupOnGraham` to manually load the necessary software component modules or edit your :kbd:`jasper` :file:`$HOME/.bashrc` to make them load automatically when you :program:`ssh` into :kbd:`jasper`.
+* follow the instructions in :ref:`moaddocs:InitialSetupOnNibi` to manually load the necessary software component modules or edit your :kbd:`jasper` :file:`$HOME/.bashrc` to make them load automatically when you :program:`ssh` into :kbd:`jasper`.
 
 
 Getting the Code

--- a/code-notes/salishsea-nemo/quickstart/index.rst
+++ b/code-notes/salishsea-nemo/quickstart/index.rst
@@ -10,7 +10,7 @@ The sections below describe *very* briefly the steps to set up and run the Salis
     :maxdepth: 2
 
     salish
-    graham
+    nibi
 
 
 Running NEMO-3.4

--- a/work_env/index.rst
+++ b/work_env/index.rst
@@ -35,13 +35,13 @@ Other machines that you may need working environments on later include:
   ``salish`` is primarily used for short development runs of the Salish Sea NEMO model.
   ``salish`` has several terabytes of storage in its :file:`/data/` filesystem.
   If your Waterhole workstation does not have access to :file:`/data/` you should open a ticket
-  via the :kbd:`Helpdesk` link on https://helpdesk.eoas.ubc.ca/ to request that EOAS Comp Staff
+  via the https://helpdesk.eoas.ubc.ca/ website to request that EOAS Comp Staff
   add a ``salish /data/`` mount on the workstation you are using.
   That will enable you to read/write files on the ``salish /data/`` filesystem without having to
   sign on to ``salish`` or copy the files from one machine to another.
-* One or more of the `Digital Research Alliance of Canada`_ (formerly Compute Canada) HPC clusters
-  :kbd:`graham.computecanada.ca` that run Linux.
+* One or more of the `Digital Research Alliance of Canada`_ (formerly Compute Canada) HPC clusters that run Linux.
   Those machines are used for longer research runs of the model.
+  The cluster that we use most often is ``nibi.alliancecan.ca`` at the University of Waterloo.
 
   .. _Digital Research Alliance of Canada: https://alliancecan.ca/en
 


### PR DESCRIPTION
* Replace detailed instructions for `graham` with those for `nibi`.
* Change to use home space (`$HOME`) for our repository clones and working environment because it is large enough,
sufficiently high performance, and backed up.